### PR TITLE
Improve mobile navigation and support link contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,13 @@
         .toc a{padding:6px 10px;border:1px solid rgba(148,163,184,.2);border-radius:999px;color:var(--muted)}
         .toc a:hover{color:var(--text)}
         .callout{border-left:3px solid var(--ring);padding:10px 14px;border-radius:10px;background:rgba(96,165,250,.08)}
+        a[href^="mailto:"]{color:var(--cta)}
+        @media(max-width:600px){
+            .nav{flex-direction:column;align-items:flex-start;height:auto;justify-content:flex-start}
+            .nav nav{display:flex;flex-direction:column;align-items:flex-start;margin-top:8px}
+            .nav nav a{margin:6px 0 0 0}
+            .nav nav a.btn{padding:8px 12px;margin-top:12px}
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Stack navigation links vertically on narrow screens so the "Get the app" button no longer wraps awkwardly
- Use high-contrast orange for mailto links such as support@vorbiz.net

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abad45085c832e9b9a36c0a445acca