### PR TITLE
style: apply mobile app color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,292 +1,633 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Vorbiz – Simple Sales Recording for Vendors</title>
-  <link rel="icon" href="enhanced_icon_512.png" sizes="any" />
-  <meta name="description" content="Vorbiz is a vendor‑facing sales recording app. Log sales fast, generate day and tax reports, and keep items organized with UPCs, variants, and quick buttons." />
-  <meta property="og:title" content="Vorbiz – Simple Sales Recording for Vendors" />
-  <meta property="og:description" content="Vendor‑only sales recording. Offline‑first. Fast item entry. Clean reports." />
-  <meta property="og:type" content="website" />
-  <meta property="og:image" content="feature-graphic.png" />
-  <meta name="theme-color" content="#0f172a" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <style>
-    :root{
-      --bs-body-bg:#043F3B;
-      --bs-body-color:#F7F9F9;
-      --bs-secondary-color:#A5B9B3;
-      --bs-primary:#00937A;
-      --bs-secondary:#065F59;
-      --bs-info:#44B299;
-      --bs-warning:#DB4814;
-      --bs-link-color:#00937A;
-      --bs-link-hover-color:#007863;
-    }
-    .navbar{
-      background:rgba(11,16,32,.6);
-      backdrop-filter:saturate(120%) blur(6px);
-      border-bottom:1px solid rgba(148,163,184,.2);
-    }
-    .logo{width:22px;height:22px;border-radius:6px;box-shadow:0 0 0 1px rgba(255,255,255,.12);}
-    .chip{display:inline-flex;align-items:center;gap:.5rem;padding:.375rem .75rem;border-radius:50rem;background:rgba(148,163,184,.08);}
-    .shot img{border-radius:1rem;border:1px solid rgba(148,163,184,.2);width:100%;height:auto;}
-    .kbd{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:.8125rem;padding:.2rem .45rem;border:1px solid rgba(148,163,184,.3);border-bottom-width:2px;border-radius:6px;background:rgba(2,6,23,.6);}
-    .card p,.card ul{color:var(--bs-secondary-color);}
-    .legal{font-size:14px;}
-  </style>
-</head>
-<body>
-<nav class="navbar navbar-expand-lg navbar-dark sticky-top">
-  <div class="container">
-    <a class="navbar-brand d-flex align-items-center gap-2 fw-bold" href="#">
-      <img src="./assets/enhanced_icon_512.png" alt="" class="logo" /> Vorbiz
-    </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbars">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbars">
-      <ul class="navbar-nav ms-auto align-items-lg-center">
-        <li class="nav-item"><a class="nav-link text-secondary" href="#features">Features</a></li>
-        <li class="nav-item"><a class="nav-link text-secondary" href="#screenshots">Screenshots</a></li>
-        <li class="nav-item"><a class="nav-link text-secondary" href="#privacy">Privacy</a></li>
-        <li class="nav-item ms-lg-3"><a class="btn btn-warning text-light" href="#download">Get the app</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
-
-<main class="container my-5">
-  <section class="row align-items-center g-4">
-    <div class="col-lg-7">
-      <div class="card bg-secondary border-0 p-4">
-        <div class="text-uppercase small fw-bold text-info">Vendor‑only sales recording</div>
-        <h1 class="display-5">Record sales fast. Keep items tidy. File taxes without headaches.</h1>
-        <p>Vorbiz is a <strong>vendor‑facing</strong> app (not a customer POS) built for markets and pop‑ups. Create locations, add items with UPCs and variants, pin quick buttons, and scan labels to ring items in seconds. Reports summarize your day, date ranges, and sales tax by location.</p>
-        <div class="d-flex flex-wrap gap-2 mt-3">
-          <span class="chip">Offline‑first</span>
-          <span class="chip">Fast item entry</span>
-          <span class="chip">Clean reports</span>
-        </div>
-        <p id="download" class="alert alert-info mt-3 mb-0 text-dark">Coming to Google Play.</p>
-      </div>
-    </div>
-    <div class="col-lg-5">
-      <div class="shot"><img src="./assets/feature-graphic.png" alt="Vorbiz feature graphic" class="img-fluid" /></div>
-    </div>
-  </section>
-
-  <section id="features" class="my-5">
-    <h2>What the app does</h2>
-    <div class="card bg-secondary border-0 p-4">
-      <h3>Locations</h3>
-      <p>Define where sales occur and which items are available there. Each location includes a <strong>name</strong>, <strong>address</strong>, and <strong>tax settings</strong>. Enable <strong>tax‑inclusive pricing</strong> if your listed price already includes tax; disable it to add tax on top.</p>
-
-      <h3>Items</h3>
-      <p>Create items with a <strong>name</strong>, <strong>price</strong>, and a <strong>UPC</strong> (12‑digit number). Vorbiz can generate a <strong>QR label</strong> from the UPC so it always scans back to the correct product. Toggle <strong>Quick Button</strong> for top sellers.</p>
-      <p>Add <strong>variants</strong> (e.g., 8oz / 12oz / 16oz) to keep your item list short. When an item has variants, the sale screen prompts you to pick the right option before adding it to the cart.</p>
-
-      <h3>Sale screen</h3>
-      <ul>
-        <li>Select the active location; any Quick Buttons appear for one‑tap adding.</li>
-        <li>If an item has variants, you'll choose the option first.</li>
-        <li>Built‑in label scanning adds items instantly.</li>
-      </ul>
-
-      <h3>Managing sales</h3>
-      <p>From the <strong>Sales List</strong>, you can update a sale's <strong>date</strong> or <strong>location</strong>. If line items or totals need changes, delete and recreate the sale with the correct details.</p>
-
-      <h3>Reporting</h3>
-      <ul>
-        <li><strong>Day Report</strong> – all sales for a single day.</li>
-        <li><strong>Date Range Report</strong> – summarized sales for any period.</li>
-        <li><strong>Sales Tax Report</strong> – tax collected by location for easy filing.</li>
-      </ul>
-
-      <h3>Keyboard shortcuts</h3>
-      <ul>
-        <li><span class="kbd">/</span> focuses the search bar</li>
-        <li><span class="kbd">Enter</span> adds the top search result</li>
-        <li><span class="kbd">Shift</span>+<span class="kbd">Enter</span> completes the sale</li>
-      </ul>
-    </div>
-  </section>
-
-  <section id="screenshots" class="my-5">
-    <h2>Screenshots</h2>
-    <div class="row g-3">
-      <div class="col-md">
-        <figure class="shot">
-          <img src="./assets/screenshot1.jpg" alt="Vorbiz sale screen" class="img-fluid" />
-          <figcaption class="figure-caption text-secondary p-2">Sale screen with Quick Buttons and scanner</figcaption>
-        </figure>
-      </div>
-      <div class="col-md">
-        <figure class="shot">
-          <img src="./assets/screenshot2.jpg" alt="Vorbiz reporting screen" class="img-fluid" />
-          <figcaption class="figure-caption text-secondary p-2">Reporting overview (day, range, tax)</figcaption>
-        </figure>
-      </div>
-    </div>
-  </section>
-
-  <section id="privacy" class="my-5">
-    <h2>Privacy Policy – Vorbiz</h2>
-    <div class="card bg-secondary border-0 p-4 legal">
-      <p><strong>Effective date:</strong> August 24, 2025</p>
-      <p>Vorbiz (“Vorbiz,” “we,” “our,” or “us”) respects your privacy. This Privacy Policy explains what we collect, how we use it, how we share it, and the rights you may have under applicable laws (including the EU/UK GDPR and the California Consumer Privacy Act as amended by the CPRA).</p>
-      <p>If you are a business user of the Vorbiz app, you may input information about your locations and sales. You control what you enter. For any personal data you input about other individuals, you are the <strong>data controller</strong> and Vorbiz acts as your <strong>processor/service provider</strong>. For your own account/profile data and our website/app telemetry, Vorbiz is the <strong>data controller</strong>.</p>
-      <hr />
-      <h3>1) Information We Collect</h3>
-      <p>We may collect the following categories of information:</p>
-      <p><strong>A. Account &amp; Subscription Info (you provide)</strong></p>
-      <ul>
-        <li>Name, email address, phone number, mailing address</li>
-        <li>Authentication details (e.g., hashed credentials)</li>
-        <li>Subscription status and plan information</li>
-      </ul>
-      <p><strong>B. Sales &amp; Business Data (you provide in-app)</strong></p>
-      <ul>
-        <li>Item names, prices, quantities, taxes, discounts</li>
-        <li>Sales timestamps and your defined <strong>location</strong> of sale</li>
-        <li>Configuration you set for locations (e.g., tax settings)</li>
-      </ul>
-      <div class="alert alert-info text-dark">
-        <p>We do <strong>not</strong> require or intend to collect your end-customers’ personal data. If you choose to enter it, you are responsible for ensuring you have a lawful basis to do so.</p>
-      </div>
-      <p><strong>C. Device &amp; Usage Data (collected automatically)</strong></p>
-      <ul>
-        <li>Device type, operating system, app version</li>
-        <li>In-app actions and general usage telemetry</li>
-        <li>IP address and coarse location (derived from IP) for security and fraud prevention</li>
-      </ul>
-      <p><strong>D. Error &amp; Diagnostic Data (crash/analytics)</strong></p>
-      <ul>
-        <li>Crash logs, error messages, stack traces</li>
-        <li>Performance metrics</li>
-        <li>Limited identifiers (e.g., IP address, device ID, app instance ID)</li>
-      </ul>
-      <div class="alert alert-info text-dark">
-        <p>Collected only to diagnose issues, improve stability, and secure the service.</p>
-      </div>
-      <p><strong>E. Camera Access (in app)</strong></p>
-      <p>The app accesses the device camera <strong>solely to scan QR codes and barcodes</strong> while you are actively using the feature. <strong>No images or video are recorded or stored</strong> by Vorbiz from the camera stream.</p>
-      <p><strong>F. Support &amp; Communications</strong></p>
-      <ul>
-        <li>Content of your messages to us (e.g., support tickets, feedback, email)</li>
-      </ul>
-      <p><strong>G. Cookies &amp; Similar Technologies (website)</strong></p>
-      <p>We may use cookies or similar technologies on vorbiz.net for essential functionality, performance, and security.</p>
-      <hr />
-      <h3>2) How We Use Information</h3>
-      <p>We use information to:</p>
-      <ul>
-        <li>Provide, operate, maintain, and improve the app and website</li>
-        <li>Set up and manage accounts, authentication, and subscriptions</li>
-        <li>Generate reports and features you request (e.g., sales summaries)</li>
-        <li>Monitor performance, debug issues, and ensure security</li>
-        <li>Communicate with you (support, updates, policy or service notices)</li>
-        <li>Comply with legal obligations and enforce our terms</li>
-      </ul>
-      <p>We <strong>do not sell or rent</strong> personal information. We also <strong>do not “share”</strong> personal information for cross-context behavioral advertising as defined by the CPRA.</p>
-      <hr />
-      <h3>3) Our Roles and Legal Bases (GDPR/UK GDPR)</h3>
-      <ul>
-        <li><strong>Controller:</strong> for your account/profile/telemetry, website usage, and our own business records. Legal bases include <strong>contract</strong> (providing the service), <strong>legitimate interests</strong> (security, debugging, improving the app), <strong>consent</strong> (where required), and <strong>legal obligation</strong>.</li>
-        <li><strong>Processor/Service Provider:</strong> for Sales &amp; Business Data you input about others. We process it <strong>only on your documented instructions</strong> (i.e., via your in-app actions and settings).</li>
-      </ul>
-      <p>If you need a <strong>Data Processing Addendum (DPA)</strong>, contact <a href="mailto:support@vorbiz.net">support@vorbiz.net</a>.</p>
-      <hr />
-      <h3>4) How We Share Information</h3>
-      <p>We share information only with:</p>
-      <ul>
-        <li><strong>Service providers / processors</strong> that help us operate (e.g., cloud hosting, databases, payment processors, crash/analytics tools, email providers). They may access personal information <strong>only</strong> to perform services for us and are bound by confidentiality and data protection obligations.</li>
-        <li><strong>Legal and safety</strong> recipients when required by law, legal process, or to protect rights, safety, or security.</li>
-        <li><strong>Business transfers</strong> (e.g., merger, acquisition). Your information may be transferred as part of the transaction and remain protected by this Policy or a successor policy at least as protective.</li>
-      </ul>
-      <p>We <strong>do not sell</strong> personal information and <strong>do not share</strong> it for cross-context behavioral advertising.</p>
-      <hr />
-      <h3>5) Data Storage, Security, and Retention</h3>
-      <ul>
-        <li><strong>Storage:</strong> Personal and sales data are stored securely in off-device databases. Data in transit is encrypted (TLS). We use industry-standard security controls and restrict access to authorized personnel and systems.</li>
-        <li><strong>Retention:</strong>
-          <ul>
-            <li>Account &amp; Subscription data: kept while your account is active and for up to <strong>3 years</strong> after closure (for records, dispute resolution, tax/legal).</li>
-            <li>Sales &amp; Business Data (processor role): retained according to your use of the service; if you request deletion or delete data in-app, we remove it from active systems, with typical backup overwrites within <strong>90 days</strong>.</li>
-            <li>Diagnostics &amp; logs: typically <strong>12–24 months</strong>, unless a longer period is required for security/forensics. These periods may vary where law or legitimate interests require longer/shorter retention.</li>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vorbiz – Simple Sales Recording for Vendors</title>
+    <link rel="icon" href="enhanced_icon_512.png" sizes="any" />
+    <meta
+      name="description"
+      content="Vorbiz is a vendor‑facing sales recording app. Log sales fast, generate day and tax reports, and keep items organized with UPCs, variants, and quick buttons."
+    />
+    <meta
+      property="og:title"
+      content="Vorbiz – Simple Sales Recording for Vendors"
+    />
+    <meta
+      property="og:description"
+      content="Vendor‑only sales recording. Offline‑first. Fast item entry. Clean reports."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="feature-graphic.png" />
+    <meta name="theme-color" content="#0f172a" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bs-body-bg: #0f172a;
+        --bs-body-color: #f8fafc;
+        --bs-secondary-color: #94a3b8;
+        --bs-primary: #00937a;
+        --bs-secondary: #1e293b;
+        --bs-info: #44b299;
+        --bs-warning: #db4814;
+        --bs-link-color: #44b299;
+        --bs-link-hover-color: #37a086;
+      }
+      .navbar {
+        background: #0f172a;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      }
+      .logo {
+        width: 22px;
+        height: 22px;
+        border-radius: 6px;
+        box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1);
+      }
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.375rem 0.75rem;
+        border-radius: 50rem;
+        background: rgba(148, 163, 184, 0.1);
+      }
+      .shot img {
+        border-radius: 1rem;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        width: 100%;
+        height: auto;
+      }
+      .kbd {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+          "Liberation Mono", "Courier New", monospace;
+        font-size: 0.8125rem;
+        padding: 0.2rem 0.45rem;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-bottom-width: 2px;
+        border-radius: 6px;
+        background: rgba(255, 255, 255, 0.05);
+      }
+      .card p,
+      .card ul {
+        color: var(--bs-secondary-color);
+      }
+      .legal {
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark sticky-top">
+      <div class="container">
+        <a
+          class="navbar-brand d-flex align-items-center gap-2 fw-bold"
+          href="#"
+        >
+          <img src="./assets/enhanced_icon_512.png" alt="" class="logo" />
+          Vorbiz
+        </a>
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbars"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbars">
+          <ul class="navbar-nav ms-auto align-items-lg-center">
+            <li class="nav-item">
+              <a class="nav-link" href="#features">Features</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#screenshots">Screenshots</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#privacy">Privacy</a>
+            </li>
+            <li class="nav-item ms-lg-3">
+              <a class="btn btn-warning text-light" href="#download"
+                >Get the app</a
+              >
+            </li>
           </ul>
-        </li>
-        <li><strong>Your Controls:</strong> Where available, you can delete records in-app. You can also request deletion via email (see Section 10).</li>
-      </ul>
-      <hr />
-      <h3>6) International Transfers</h3>
-      <p>We may process and store data in the United States and other countries. Where required, we use appropriate safeguards such as <strong>Standard Contractual Clauses (SCCs)</strong> for EEA/UK transfers.</p>
-      <hr />
-      <h3>7) Your Privacy Rights</h3>
-      <p>Your rights depend on your location and applicable law. They may include:</p>
-      <ul>
-        <li><strong>Access</strong>: obtain a copy of your personal data</li>
-        <li><strong>Correction</strong>: rectify inaccurate or incomplete data</li>
-        <li><strong>Deletion</strong>: request erasure of personal data</li>
-        <li><strong>Restriction/Objection</strong>: limit or object to certain processing</li>
-        <li><strong>Portability</strong>: receive your data in a portable format</li>
-        <li><strong>Withdraw consent</strong> where we rely on consent (without affecting prior lawful processing)</li>
-      </ul>
-      <p><strong>How to exercise:</strong> email <a href="mailto:support@vorbiz.net">support@vorbiz.net</a> with your request, your relationship to Vorbiz, and the data scope. We may need to verify your identity.</p>
-      <p><strong>California (CCPA/CPRA) notices:</strong></p>
-      <ul>
-        <li>We <strong>do not sell</strong> personal information and <strong>do not share</strong> personal information for cross-context behavioral advertising.</li>
-        <li>You have the rights to <strong>know</strong>, <strong>delete</strong>, <strong>correct</strong>, and <strong>non-discrimination</strong>. You may use an <strong>authorized agent</strong>; we will require proof of authorization.</li>
-        <li>We do not use <strong>Sensitive Personal Information</strong> for inferring characteristics or for purposes beyond those permitted by CPRA.</li>
-      </ul>
-      <hr />
-      <h3>8) Children’s Privacy</h3>
-      <p>Vorbiz is not directed to children under 13, and we do not knowingly collect personal information from children. If you believe a child has provided personal information, contact <a href="mailto:support@vorbiz.net">support@vorbiz.net</a> and we will take appropriate steps to delete it.</p>
-      <hr />
-      <h3>9) Cookies &amp; “Do Not Track”</h3>
-      <p>We may use cookies on the website for essential and performance purposes. Your browser may offer a “Do Not Track” setting; because there is no industry standard, we do not respond to DNT signals. You can manage cookies through your browser settings.</p>
-      <hr />
-      <h3>10) Data Requests &amp; Deletion</h3>
-      <p>To access, correct, export, or delete your data—or to terminate your account—email <a href="mailto:support@vorbiz.net">support@vorbiz.net</a> with the subject line <strong>“Privacy Request”</strong> and describe your request. We will respond as required by law. For deletion, we remove data from active systems and schedule removal from backups during normal rotation (typically within <strong>90 days</strong>).</p>
-      <hr />
-      <h3>11) Third-Party Services</h3>
-      <p>Our service may include integrations with third-party providers (e.g., hosting, payments, crash reporting/analytics, email delivery). Their processing of your data is limited to providing their services to us, under contracts that restrict use for any other purpose.</p>
-      <hr />
-      <h3>12) Changes to This Policy</h3>
-      <p>We may update this Policy from time to time. If we make material changes, we will update the “Effective date” above and, where appropriate, provide additional notice (e.g., in-app or email).</p>
-      <hr />
-      <h3>13) Contact Us</h3>
-      <p>Questions or requests about this Policy or your data:<br /><strong>Email:</strong> <a href="mailto:support@vorbiz.net">support@vorbiz.net</a></p>
-      <hr />
-      <h3>CPRA Category Mapping (Summary)</h3>
-      <ul>
-        <li><strong>Identifiers:</strong> name, email, phone, address, IP address, device IDs (no sale/share)</li>
-        <li><strong>Customer Records:</strong> subscription/account details (no sale/share)</li>
-        <li><strong>Commercial Information:</strong> subscription plan, in-app purchases (if any) (no sale/share)</li>
-        <li><strong>Internet/Network Activity:</strong> app/website usage, logs, diagnostics (no sale/share)</li>
-        <li><strong>Geolocation (coarse):</strong> derived from IP for security/fraud (no sale/share)</li>
-        <li><strong>Sensitive Personal Information:</strong> not sought; if provided by you, we do not use it to infer characteristics</li>
-      </ul>
-    </div>
-  </section>
-</main>
+        </div>
+      </div>
+    </nav>
 
-<footer class="container py-4 text-secondary">
-  <div class="d-flex justify-content-between align-items-center gap-3 flex-wrap">
-    <div>© <span id="y"></span> Vorbiz</div>
-    <div>Built for markets and vendor booths</div>
-  </div>
-</footer>
+    <main class="container my-5">
+      <section class="row align-items-center g-4">
+        <div class="col-lg-7">
+          <div class="card bg-secondary border-0 p-4">
+            <div class="text-uppercase small fw-bold text-info">
+              Vendor‑only sales recording
+            </div>
+            <h1 class="display-5">
+              Record sales fast. Keep items tidy. File taxes without headaches.
+            </h1>
+            <p>
+              Vorbiz is a <strong>vendor‑facing</strong> app (not a customer
+              POS) built for markets and pop‑ups. Create locations, add items
+              with UPCs and variants, pin quick buttons, and scan labels to ring
+              items in seconds. Reports summarize your day, date ranges, and
+              sales tax by location.
+            </p>
+            <div class="d-flex flex-wrap gap-2 mt-3">
+              <span class="chip">Offline‑first</span>
+              <span class="chip">Fast item entry</span>
+              <span class="chip">Clean reports</span>
+            </div>
+            <p
+              id="download"
+              class="alert bg-info text-light border-0 mt-3 mb-0"
+            >
+              Coming to Google Play.
+            </p>
+          </div>
+        </div>
+        <div class="col-lg-5">
+          <div class="shot">
+            <img
+              src="./assets/feature-graphic.png"
+              alt="Vorbiz feature graphic"
+              class="img-fluid"
+            />
+          </div>
+        </div>
+      </section>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-<script>
-  (function(){
-    const d = new Date();
-    const y = d.getFullYear();
-    const yEl = document.getElementById('y');
-    if(yEl) yEl.textContent = y;
-  })();
-</script>
-</body>
+      <section id="features" class="my-5">
+        <h2>What the app does</h2>
+        <div class="card bg-secondary border-0 p-4">
+          <h3>Locations</h3>
+          <p>
+            Define where sales occur and which items are available there. Each
+            location includes a <strong>name</strong>, <strong>address</strong>,
+            and <strong>tax settings</strong>. Enable
+            <strong>tax‑inclusive pricing</strong> if your listed price already
+            includes tax; disable it to add tax on top.
+          </p>
+
+          <h3>Items</h3>
+          <p>
+            Create items with a <strong>name</strong>, <strong>price</strong>,
+            and a <strong>UPC</strong> (12‑digit number). Vorbiz can generate a
+            <strong>QR label</strong> from the UPC so it always scans back to
+            the correct product. Toggle <strong>Quick Button</strong> for top
+            sellers.
+          </p>
+          <p>
+            Add <strong>variants</strong> (e.g., 8oz / 12oz / 16oz) to keep your
+            item list short. When an item has variants, the sale screen prompts
+            you to pick the right option before adding it to the cart.
+          </p>
+
+          <h3>Sale screen</h3>
+          <ul>
+            <li>
+              Select the active location; any Quick Buttons appear for one‑tap
+              adding.
+            </li>
+            <li>If an item has variants, you'll choose the option first.</li>
+            <li>Built‑in label scanning adds items instantly.</li>
+          </ul>
+
+          <h3>Managing sales</h3>
+          <p>
+            From the <strong>Sales List</strong>, you can update a sale's
+            <strong>date</strong> or <strong>location</strong>. If line items or
+            totals need changes, delete and recreate the sale with the correct
+            details.
+          </p>
+
+          <h3>Reporting</h3>
+          <ul>
+            <li><strong>Day Report</strong> – all sales for a single day.</li>
+            <li>
+              <strong>Date Range Report</strong> – summarized sales for any
+              period.
+            </li>
+            <li>
+              <strong>Sales Tax Report</strong> – tax collected by location for
+              easy filing.
+            </li>
+          </ul>
+
+          <h3>Keyboard shortcuts</h3>
+          <ul>
+            <li><span class="kbd">/</span> focuses the search bar</li>
+            <li><span class="kbd">Enter</span> adds the top search result</li>
+            <li>
+              <span class="kbd">Shift</span>+<span class="kbd">Enter</span>
+              completes the sale
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section id="screenshots" class="my-5">
+        <h2>Screenshots</h2>
+        <div class="row g-3">
+          <div class="col-md">
+            <figure class="shot">
+              <img
+                src="./assets/screenshot1.jpg"
+                alt="Vorbiz sale screen"
+                class="img-fluid"
+              />
+              <figcaption class="figure-caption text-secondary p-2">
+                Sale screen with Quick Buttons and scanner
+              </figcaption>
+            </figure>
+          </div>
+          <div class="col-md">
+            <figure class="shot">
+              <img
+                src="./assets/screenshot2.jpg"
+                alt="Vorbiz reporting screen"
+                class="img-fluid"
+              />
+              <figcaption class="figure-caption text-secondary p-2">
+                Reporting overview (day, range, tax)
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section id="privacy" class="my-5">
+        <h2>Privacy Policy – Vorbiz</h2>
+        <div class="card bg-secondary border-0 p-4 legal">
+          <p><strong>Effective date:</strong> August 24, 2025</p>
+          <p>
+            Vorbiz (“Vorbiz,” “we,” “our,” or “us”) respects your privacy. This
+            Privacy Policy explains what we collect, how we use it, how we share
+            it, and the rights you may have under applicable laws (including the
+            EU/UK GDPR and the California Consumer Privacy Act as amended by the
+            CPRA).
+          </p>
+          <p>
+            If you are a business user of the Vorbiz app, you may input
+            information about your locations and sales. You control what you
+            enter. For any personal data you input about other individuals, you
+            are the <strong>data controller</strong> and Vorbiz acts as your
+            <strong>processor/service provider</strong>. For your own
+            account/profile data and our website/app telemetry, Vorbiz is the
+            <strong>data controller</strong>.
+          </p>
+          <hr />
+          <h3>1) Information We Collect</h3>
+          <p>We may collect the following categories of information:</p>
+          <p>
+            <strong>A. Account &amp; Subscription Info (you provide)</strong>
+          </p>
+          <ul>
+            <li>Name, email address, phone number, mailing address</li>
+            <li>Authentication details (e.g., hashed credentials)</li>
+            <li>Subscription status and plan information</li>
+          </ul>
+          <p>
+            <strong>B. Sales &amp; Business Data (you provide in-app)</strong>
+          </p>
+          <ul>
+            <li>Item names, prices, quantities, taxes, discounts</li>
+            <li>
+              Sales timestamps and your defined <strong>location</strong> of
+              sale
+            </li>
+            <li>Configuration you set for locations (e.g., tax settings)</li>
+          </ul>
+          <div class="alert bg-info text-light border-0">
+            <p>
+              We do <strong>not</strong> require or intend to collect your
+              end-customers’ personal data. If you choose to enter it, you are
+              responsible for ensuring you have a lawful basis to do so.
+            </p>
+          </div>
+          <p>
+            <strong
+              >C. Device &amp; Usage Data (collected automatically)</strong
+            >
+          </p>
+          <ul>
+            <li>Device type, operating system, app version</li>
+            <li>In-app actions and general usage telemetry</li>
+            <li>
+              IP address and coarse location (derived from IP) for security and
+              fraud prevention
+            </li>
+          </ul>
+          <p>
+            <strong>D. Error &amp; Diagnostic Data (crash/analytics)</strong>
+          </p>
+          <ul>
+            <li>Crash logs, error messages, stack traces</li>
+            <li>Performance metrics</li>
+            <li>
+              Limited identifiers (e.g., IP address, device ID, app instance ID)
+            </li>
+          </ul>
+          <div class="alert bg-info text-light border-0">
+            <p>
+              Collected only to diagnose issues, improve stability, and secure
+              the service.
+            </p>
+          </div>
+          <p><strong>E. Camera Access (in app)</strong></p>
+          <p>
+            The app accesses the device camera
+            <strong>solely to scan QR codes and barcodes</strong> while you are
+            actively using the feature.
+            <strong>No images or video are recorded or stored</strong> by Vorbiz
+            from the camera stream.
+          </p>
+          <p><strong>F. Support &amp; Communications</strong></p>
+          <ul>
+            <li>
+              Content of your messages to us (e.g., support tickets, feedback,
+              email)
+            </li>
+          </ul>
+          <p>
+            <strong>G. Cookies &amp; Similar Technologies (website)</strong>
+          </p>
+          <p>
+            We may use cookies or similar technologies on vorbiz.net for
+            essential functionality, performance, and security.
+          </p>
+          <hr />
+          <h3>2) How We Use Information</h3>
+          <p>We use information to:</p>
+          <ul>
+            <li>Provide, operate, maintain, and improve the app and website</li>
+            <li>
+              Set up and manage accounts, authentication, and subscriptions
+            </li>
+            <li>
+              Generate reports and features you request (e.g., sales summaries)
+            </li>
+            <li>Monitor performance, debug issues, and ensure security</li>
+            <li>
+              Communicate with you (support, updates, policy or service notices)
+            </li>
+            <li>Comply with legal obligations and enforce our terms</li>
+          </ul>
+          <p>
+            We <strong>do not sell or rent</strong> personal information. We
+            also <strong>do not “share”</strong> personal information for
+            cross-context behavioral advertising as defined by the CPRA.
+          </p>
+          <hr />
+          <h3>3) Our Roles and Legal Bases (GDPR/UK GDPR)</h3>
+          <ul>
+            <li>
+              <strong>Controller:</strong> for your account/profile/telemetry,
+              website usage, and our own business records. Legal bases include
+              <strong>contract</strong> (providing the service),
+              <strong>legitimate interests</strong> (security, debugging,
+              improving the app), <strong>consent</strong> (where required), and
+              <strong>legal obligation</strong>.
+            </li>
+            <li>
+              <strong>Processor/Service Provider:</strong> for Sales &amp;
+              Business Data you input about others. We process it
+              <strong>only on your documented instructions</strong> (i.e., via
+              your in-app actions and settings).
+            </li>
+          </ul>
+          <p>
+            If you need a <strong>Data Processing Addendum (DPA)</strong>,
+            contact <a href="mailto:support@vorbiz.net">support@vorbiz.net</a>.
+          </p>
+          <hr />
+          <h3>4) How We Share Information</h3>
+          <p>We share information only with:</p>
+          <ul>
+            <li>
+              <strong>Service providers / processors</strong> that help us
+              operate (e.g., cloud hosting, databases, payment processors,
+              crash/analytics tools, email providers). They may access personal
+              information <strong>only</strong> to perform services for us and
+              are bound by confidentiality and data protection obligations.
+            </li>
+            <li>
+              <strong>Legal and safety</strong> recipients when required by law,
+              legal process, or to protect rights, safety, or security.
+            </li>
+            <li>
+              <strong>Business transfers</strong> (e.g., merger, acquisition).
+              Your information may be transferred as part of the transaction and
+              remain protected by this Policy or a successor policy at least as
+              protective.
+            </li>
+          </ul>
+          <p>
+            We <strong>do not sell</strong> personal information and
+            <strong>do not share</strong> it for cross-context behavioral
+            advertising.
+          </p>
+          <hr />
+          <h3>5) Data Storage, Security, and Retention</h3>
+          <ul>
+            <li>
+              <strong>Storage:</strong> Personal and sales data are stored
+              securely in off-device databases. Data in transit is encrypted
+              (TLS). We use industry-standard security controls and restrict
+              access to authorized personnel and systems.
+            </li>
+            <li>
+              <strong>Retention:</strong>
+              <ul>
+                <li>
+                  Account &amp; Subscription data: kept while your account is
+                  active and for up to <strong>3 years</strong> after closure
+                  (for records, dispute resolution, tax/legal).
+                </li>
+                <li>
+                  Sales &amp; Business Data (processor role): retained according
+                  to your use of the service; if you request deletion or delete
+                  data in-app, we remove it from active systems, with typical
+                  backup overwrites within <strong>90 days</strong>.
+                </li>
+                <li>
+                  Diagnostics &amp; logs: typically
+                  <strong>12–24 months</strong>, unless a longer period is
+                  required for security/forensics. These periods may vary where
+                  law or legitimate interests require longer/shorter retention.
+                </li>
+              </ul>
+            </li>
+            <li>
+              <strong>Your Controls:</strong> Where available, you can delete
+              records in-app. You can also request deletion via email (see
+              Section 10).
+            </li>
+          </ul>
+          <hr />
+          <h3>6) International Transfers</h3>
+          <p>
+            We may process and store data in the United States and other
+            countries. Where required, we use appropriate safeguards such as
+            <strong>Standard Contractual Clauses (SCCs)</strong> for EEA/UK
+            transfers.
+          </p>
+          <hr />
+          <h3>7) Your Privacy Rights</h3>
+          <p>
+            Your rights depend on your location and applicable law. They may
+            include:
+          </p>
+          <ul>
+            <li>
+              <strong>Access</strong>: obtain a copy of your personal data
+            </li>
+            <li>
+              <strong>Correction</strong>: rectify inaccurate or incomplete data
+            </li>
+            <li><strong>Deletion</strong>: request erasure of personal data</li>
+            <li>
+              <strong>Restriction/Objection</strong>: limit or object to certain
+              processing
+            </li>
+            <li>
+              <strong>Portability</strong>: receive your data in a portable
+              format
+            </li>
+            <li>
+              <strong>Withdraw consent</strong> where we rely on consent
+              (without affecting prior lawful processing)
+            </li>
+          </ul>
+          <p>
+            <strong>How to exercise:</strong> email
+            <a href="mailto:support@vorbiz.net">support@vorbiz.net</a> with your
+            request, your relationship to Vorbiz, and the data scope. We may
+            need to verify your identity.
+          </p>
+          <p><strong>California (CCPA/CPRA) notices:</strong></p>
+          <ul>
+            <li>
+              We <strong>do not sell</strong> personal information and
+              <strong>do not share</strong> personal information for
+              cross-context behavioral advertising.
+            </li>
+            <li>
+              You have the rights to <strong>know</strong>,
+              <strong>delete</strong>, <strong>correct</strong>, and
+              <strong>non-discrimination</strong>. You may use an
+              <strong>authorized agent</strong>; we will require proof of
+              authorization.
+            </li>
+            <li>
+              We do not use <strong>Sensitive Personal Information</strong> for
+              inferring characteristics or for purposes beyond those permitted
+              by CPRA.
+            </li>
+          </ul>
+          <hr />
+          <h3>8) Children’s Privacy</h3>
+          <p>
+            Vorbiz is not directed to children under 13, and we do not knowingly
+            collect personal information from children. If you believe a child
+            has provided personal information, contact
+            <a href="mailto:support@vorbiz.net">support@vorbiz.net</a> and we
+            will take appropriate steps to delete it.
+          </p>
+          <hr />
+          <h3>9) Cookies &amp; “Do Not Track”</h3>
+          <p>
+            We may use cookies on the website for essential and performance
+            purposes. Your browser may offer a “Do Not Track” setting; because
+            there is no industry standard, we do not respond to DNT signals. You
+            can manage cookies through your browser settings.
+          </p>
+          <hr />
+          <h3>10) Data Requests &amp; Deletion</h3>
+          <p>
+            To access, correct, export, or delete your data—or to terminate your
+            account—email
+            <a href="mailto:support@vorbiz.net">support@vorbiz.net</a> with the
+            subject line <strong>“Privacy Request”</strong> and describe your
+            request. We will respond as required by law. For deletion, we remove
+            data from active systems and schedule removal from backups during
+            normal rotation (typically within <strong>90 days</strong>).
+          </p>
+          <hr />
+          <h3>11) Third-Party Services</h3>
+          <p>
+            Our service may include integrations with third-party providers
+            (e.g., hosting, payments, crash reporting/analytics, email
+            delivery). Their processing of your data is limited to providing
+            their services to us, under contracts that restrict use for any
+            other purpose.
+          </p>
+          <hr />
+          <h3>12) Changes to This Policy</h3>
+          <p>
+            We may update this Policy from time to time. If we make material
+            changes, we will update the “Effective date” above and, where
+            appropriate, provide additional notice (e.g., in-app or email).
+          </p>
+          <hr />
+          <h3>13) Contact Us</h3>
+          <p>
+            Questions or requests about this Policy or your data:<br /><strong
+              >Email:</strong
+            >
+            <a href="mailto:support@vorbiz.net">support@vorbiz.net</a>
+          </p>
+          <hr />
+          <h3>CPRA Category Mapping (Summary)</h3>
+          <ul>
+            <li>
+              <strong>Identifiers:</strong> name, email, phone, address, IP
+              address, device IDs (no sale/share)
+            </li>
+            <li>
+              <strong>Customer Records:</strong> subscription/account details
+              (no sale/share)
+            </li>
+            <li>
+              <strong>Commercial Information:</strong> subscription plan, in-app
+              purchases (if any) (no sale/share)
+            </li>
+            <li>
+              <strong>Internet/Network Activity:</strong> app/website usage,
+              logs, diagnostics (no sale/share)
+            </li>
+            <li>
+              <strong>Geolocation (coarse):</strong> derived from IP for
+              security/fraud (no sale/share)
+            </li>
+            <li>
+              <strong>Sensitive Personal Information:</strong> not sought; if
+              provided by you, we do not use it to infer characteristics
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
+
+    <footer class="container py-4 text-secondary">
+      <div
+        class="d-flex justify-content-between align-items-center gap-3 flex-wrap"
+      >
+        <div>© <span id="y"></span> Vorbiz</div>
+        <div>Built for markets and vendor booths</div>
+      </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+      (function () {
+        const d = new Date();
+        const y = d.getFullYear();
+        const yEl = document.getElementById("y");
+        if (yEl) yEl.textContent = y;
+      })();
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle site with dark palette from mobile app for better readability
- update navbar and alerts to keep text high-contrast

## Testing
- `npx -y prettier@3.1.0 --check index.html`


------
https://chatgpt.com/codex/tasks/task_e_68bd04b7d9e4832e903a8996ef86808b