### PR TITLE
Improve small text contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,8 @@
       :root {
         --bs-body-bg: #0f172a;
         --bs-body-color: #f8fafc;
-        --bs-secondary-color: #94a3b8;
+        /* Improved contrast for small text */
+        --bs-secondary-color: #cbd5e1;
         --bs-primary: #00937a;
         --bs-secondary: #1e293b;
         --bs-info: #44b299;
@@ -52,11 +53,11 @@
         gap: 0.5rem;
         padding: 0.375rem 0.75rem;
         border-radius: 50rem;
-        background: rgba(148, 163, 184, 0.1);
+        background: rgba(203, 213, 225, 0.1);
       }
       .shot img {
         border-radius: 1rem;
-        border: 1px solid rgba(148, 163, 184, 0.2);
+        border: 1px solid rgba(203, 213, 225, 0.2);
         width: 100%;
         height: auto;
       }


### PR DESCRIPTION
## Summary
- Increase secondary text color to #cbd5e1 for better readability
- Adjust chip background and screenshot border colors to match new palette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd80600044832eaf90c81f7a4f90c1