### PR TITLE
Improve text contrast in info alerts

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
             </div>
             <p
               id="download"
-              class="alert bg-info text-light border-0 mt-3 mb-0"
+              class="alert bg-info text-dark border-0 mt-3 mb-0"
             >
               Coming to Google Play.
             </p>
@@ -301,7 +301,7 @@
             </li>
             <li>Configuration you set for locations (e.g., tax settings)</li>
           </ul>
-          <div class="alert bg-info text-light border-0">
+          <div class="alert bg-info text-dark border-0">
             <p>
               We do <strong>not</strong> require or intend to collect your
               end-customers’ personal data. If you choose to enter it, you are
@@ -331,7 +331,7 @@
               Limited identifiers (e.g., IP address, device ID, app instance ID)
             </li>
           </ul>
-          <div class="alert bg-info text-light border-0">
+          <div class="alert bg-info text-dark border-0">
             <p>
               Collected only to diagnose issues, improve stability, and secure
               the service.


### PR DESCRIPTION
## Summary
- switch info alert text to dark for better contrast

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bd814ecc30832ea6d98b29a340c41f