### PR TITLE
feat: apply app color theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,33 +19,33 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="feature-graphic.png" />
-    <meta name="theme-color" content="#0f172a" />
+    <meta name="theme-color" content="#00937a" />
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
     />
     <style>
       :root {
-        --bs-body-bg: #0f172a;
-        --bs-body-color: #f8fafc;
+        --bs-body-bg: #ffffff;
+        --bs-body-color: #0f172a;
         /* Improved contrast for small text */
-        --bs-secondary-color: #cbd5e1;
+        --bs-secondary-color: #475569;
         --bs-primary: #00937a;
-        --bs-secondary: #1e293b;
+        --bs-secondary: #f1f5f9;
         --bs-info: #44b299;
         --bs-warning: #db4814;
-        --bs-link-color: #44b299;
-        --bs-link-hover-color: #37a086;
+        --bs-link-color: #00937a;
+        --bs-link-hover-color: #006d5b;
       }
       .navbar {
-        background: #0f172a;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        background: var(--bs-primary);
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
       }
       .logo {
         width: 22px;
         height: 22px;
         border-radius: 6px;
-        box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1);
+        box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
       }
       .chip {
         display: inline-flex;
@@ -53,23 +53,24 @@
         gap: 0.5rem;
         padding: 0.375rem 0.75rem;
         border-radius: 50rem;
-        background: rgba(203, 213, 225, 0.1);
+        background: rgba(0, 147, 122, 0.1);
       }
       .shot img {
         border-radius: 1rem;
-        border: 1px solid rgba(203, 213, 225, 0.2);
+        border: 1px solid rgba(203, 213, 225, 0.5);
         width: 100%;
         height: auto;
       }
       .kbd {
-        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
           "Liberation Mono", "Courier New", monospace;
         font-size: 0.8125rem;
         padding: 0.2rem 0.45rem;
-        border: 1px solid rgba(255, 255, 255, 0.2);
+        border: 1px solid rgba(0, 0, 0, 0.2);
         border-bottom-width: 2px;
         border-radius: 6px;
-        background: rgba(255, 255, 255, 0.05);
+        background: rgba(0, 0, 0, 0.05);
       }
       .card p,
       .card ul {
@@ -141,10 +142,7 @@
               <span class="chip">Fast item entry</span>
               <span class="chip">Clean reports</span>
             </div>
-            <p
-              id="download"
-              class="alert bg-info text-dark border-0 mt-3 mb-0"
-            >
+            <p id="download" class="alert bg-info text-dark border-0 mt-3 mb-0">
               Coming to Google Play.
             </p>
           </div>


### PR DESCRIPTION
## Summary
- restyle site to match app color scheme
- update metadata and navigation colors to use the app green
- lighten page backgrounds and adjust accent styles

## Testing
- `npx --yes prettier -c index.html`


------
https://chatgpt.com/codex/tasks/task_e_68bd82f6ce18832eba7ab5f4b74b9419