### PR TITLE
Add terms of service section

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,9 @@
               <a class="nav-link" href="#screenshots">Screenshots</a>
             </li>
             <li class="nav-item">
+              <a class="nav-link" href="#terms">Terms</a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link" href="#privacy">Privacy</a>
             </li>
             <li class="nav-item ms-lg-3">
@@ -262,9 +265,337 @@
         </div>
       </section>
 
-        <section id="privacy" class="my-5">
-          <h2>Privacy Policy – Vorbiz</h2>
-          <div class="card p-4 legal">
+      <section id="terms" class="my-5">
+        <h2>Terms of Service – Vorbiz</h2>
+        <div class="card p-4 legal">
+          <p><strong>Effective Date:</strong> September 17, 2025</p>
+          <p>
+            <strong>Provider:</strong> Joshua Wetzel, sole proprietorship (the
+            “Company,” “we,” “us,” or “our”)
+          </p>
+          <p>
+            <strong>Contact:</strong>
+            <a href="mailto:support@vorbiz.net">support@vorbiz.net</a>
+          </p>
+
+          <h3>1. What We Are</h3>
+          <p>
+            Vorbiz is a mobile-first sales tracking and reporting app for small
+            vendors. It is intended for business use only (B2B). Some limited web
+            views may be introduced in the future, but the web will not provide
+            full app functionality.
+          </p>
+
+          <h3>2. Acceptance of Terms</h3>
+          <p>
+            By creating an account or using the app, you agree to these Terms of
+            Service (“Terms”). If you do not agree, do not use Vorbiz.
+          </p>
+
+          <h3>3. Accounts &amp; Eligibility</h3>
+          <p>
+            Business use only. Accounts are intended for businesses; we do not
+            target consumers or minors.
+          </p>
+          <ul>
+            <li>
+              <strong>Registration.</strong> Accounts are created via email +
+              password only. You must provide accurate information and keep
+              credentials confidential.
+            </li>
+            <li>
+              <strong>Single role.</strong> All users have the same account type
+              (no role hierarchy).
+            </li>
+          </ul>
+
+          <h3>4. Subscriptions, Billing &amp; Refunds</h3>
+          <ul>
+            <li><strong>Tiers.</strong> Vorbiz offers a Free tier and paid Basic/Pro tiers.</li>
+            <li>
+              <strong>Billing.</strong> Paid tiers are monthly subscriptions
+              processed through Google Play and managed via RevenueCat.
+            </li>
+            <li><strong>Trials.</strong> No free trial is offered.</li>
+            <li>
+              <strong>Refunds.</strong> Refunds follow Google Play’s policies.
+              Any additional goodwill refunds are discretionary and not part of
+              these Terms.
+            </li>
+            <li>
+              <strong>Auto-renewal &amp; cancellation.</strong> Subscriptions
+              auto-renew until canceled through the Play Store. Deleting the app
+              does not cancel your subscription.
+            </li>
+            <li>
+              <strong>Feature scope.</strong> Features may differ by tier and may
+              be added, removed, or reallocated at our discretion. The free tier
+              has no guarantee of uptime, retention, or support.
+            </li>
+          </ul>
+
+          <h3>5. Data &amp; Privacy</h3>
+          <p><strong>Data we collect.</strong></p>
+          <ul>
+            <li>
+              Vendor account info: name, email, hashed password, business name
+            </li>
+            <li>
+              Sales records: transactions, line items, prices, taxes,
+              timestamps, location IDs
+            </li>
+            <li>
+              Customer data: planned for future releases (e.g., customer name,
+              email, phone)
+            </li>
+            <li>
+              Device &amp; analytics: device ID, app version, crash logs, usage
+              analytics
+            </li>
+            <li>
+              No payment card data is stored by us (billing is via
+              Google/RevenueCat).
+            </li>
+          </ul>
+          <p>
+            <strong>Authoritative copy.</strong> The server backup is the
+            authoritative data. A local device copy is a replica to support
+            offline use and is wiped on logout.
+          </p>
+          <p><strong>Third-party processors.</strong> We use:</p>
+          <ul>
+            <li>Supabase (database/auth)</li>
+            <li>Google Play (billing)</li>
+            <li>RevenueCat (subscription management)</li>
+            <li>Sentry (error logging/analytics)</li>
+            <li>Brevo (email)</li>
+          </ul>
+          <p>
+            <strong>Privacy Policy.</strong> Additional details appear in our
+            separate Privacy Policy (incorporated by reference).
+          </p>
+
+          <h3>6. Your Responsibilities</h3>
+          <p>You agree that:</p>
+          <ul>
+            <li>You will not use Vorbiz for illegal sales or unlawful purposes.</li>
+            <li>You will not submit fraudulent or misleading data or reports.</li>
+            <li>
+              You will not reverse engineer, tamper with, or scrape the app or
+              services.
+            </li>
+            <li>
+              You will not share accounts outside your organization without
+              permission.
+            </li>
+            <li>
+              You will not use Vorbiz to sell restricted goods (including
+              firearms, alcohol, tobacco, cannabis, adult material, or any items
+              prohibited by law) unless you are legally licensed.
+            </li>
+            <li>
+              You are solely responsible for all filings and submissions to tax
+              authorities. Vorbiz is not an accountant, tax preparer, or system
+              of record—it is a helpful tool only.
+            </li>
+          </ul>
+
+          <h3>7. Intellectual Property &amp; Your Data</h3>
+          <ul>
+            <li>
+              <strong>Our IP.</strong> All rights, title, and interest in the
+              app, branding, software, and documentation are owned by Joshua
+              Wetzel.
+            </li>
+            <li>
+              <strong>Your data.</strong> You retain ownership of your own sales
+              data. You may export your data subject to technical availability
+              and reasonable use limits.
+            </li>
+            <li>
+              <strong>Restrictions.</strong> You may not copy, scrape, or
+              repurpose the app’s code, design, or databases; you may not remove
+              proprietary notices.
+            </li>
+          </ul>
+
+          <h3>8. Service Availability &amp; Changes</h3>
+          <p>
+            We may add, change, or remove features at any time. We do not
+            guarantee uptime, availability, or that the app is error-free.
+          </p>
+          <p>
+            <strong>Updates to Terms.</strong> We may update these Terms
+            effective immediately upon posting in the app or site. Continued use
+            constitutes acceptance of the updated Terms.
+          </p>
+          <p>
+            <strong>Third-party dependencies.</strong> The service relies on
+            external providers (Supabase, Google Play, RevenueCat, Sentry,
+            Brevo). Outages or changes in those services may affect
+            availability; we are not liable for those impacts.
+          </p>
+          <p><strong>No SLA.</strong> We do not provide service-level agreements.</p>
+          <p>
+            Support is provided via email on a best-effort basis with no
+            guaranteed response time.
+          </p>
+
+          <h3>9. Data Retention &amp; Export</h3>
+          <p><strong>User control.</strong> Vendors may export their own data at any time while their subscription is active.</p>
+          <p><strong>Retention policy.</strong></p>
+          <ul>
+            <li><strong>Active (“hot”) storage:</strong> 5 years of sales data is maintained and accessible through the app.</li>
+            <li><strong>Archived (“cold”) storage:</strong> up to an additional 10 years of sales data is retained in secure offline/near-line backups.</li>
+          </ul>
+          <p>
+            <strong>Accessing archived data.</strong> Cold storage records are not
+            accessible through the app interface. Vendors may request access by
+            emailing <a href="mailto:support@vorbiz.net">support@vorbiz.net</a>,
+            and reasonable effort will be made to provide the requested data.
+          </p>
+          <p>
+            <strong>Deletion.</strong> Upon account termination, data may be
+            archived according to the retention schedule above, unless deletion
+            is required by law.
+          </p>
+          <p>
+            <strong>Not a legal record.</strong> Vorbiz retains data for
+            convenience only. Vendors remain solely responsible for maintaining
+            legally required records and producing them to authorities if
+            requested.
+          </p>
+
+          <h3>10. Termination &amp; Suspension</h3>
+          <p>
+            We may suspend or terminate your access immediately for misuse,
+            fraud, or system abuse, or as required by law. You may stop using the
+            app at any time; subscription cancellations must be handled through
+            the Play Store.
+          </p>
+
+          <h3>11. Disclaimers</h3>
+          <p>To the maximum extent permitted by law:</p>
+          <ul>
+            <li>The services are provided “AS IS” and “AS AVAILABLE.”</li>
+            <li>
+              We do not warrant accuracy, completeness, or fitness for a
+              particular purpose.
+            </li>
+            <li>We do not warrant tax calculations, reports, or compliance outcomes.</li>
+            <li>We do not provide legal, tax, or accounting advice.</li>
+            <li>
+              Reports and exports are based on user-entered data and are not
+              certified for tax, audit, or legal proceedings.
+            </li>
+          </ul>
+
+          <h3>12. Limitation of Liability</h3>
+          <p>To the maximum extent permitted by law:</p>
+          <ul>
+            <li>
+              <strong>No indirect damages.</strong> We are not liable for any
+              indirect, incidental, special, consequential, or exemplary damages,
+              including lost profits or revenue.
+            </li>
+            <li>
+              <strong>Data &amp; downtime.</strong> We are not liable for data loss
+              (including device wipe, user error, sync failure, or provider
+              outage) or for service interruptions.
+            </li>
+            <li>
+              <strong>Cap.</strong> Our total liability for any claim shall not
+              exceed the amount you paid for the service in the one (1) month
+              preceding the event giving rise to liability (or $0 if you are on
+              the Free tier).
+            </li>
+          </ul>
+
+          <h3>13. Indemnification</h3>
+          <p>
+            You agree to indemnify and hold harmless the Company from claims
+            arising out of your misuse of the services, your data submissions, or
+            your violation of these Terms or applicable laws.
+          </p>
+
+          <h3>14. Governing Law; Arbitration; Class-Action Waiver</h3>
+          <ul>
+            <li>
+              <strong>Governing law.</strong> These Terms are governed by the
+              laws of the State of Louisiana, USA, without regard to
+              conflict-of-laws rules.
+            </li>
+            <li>
+              <strong>Binding arbitration.</strong> Any dispute, claim, or
+              controversy arising out of or relating to these Terms or the
+              services will be resolved by binding arbitration administered by a
+              reputable arbitration provider (e.g., AAA under its Commercial
+              Rules), conducted in Louisiana, in English, before a single
+              arbitrator. Judgment on the award may be entered in any court of
+              competent jurisdiction.
+            </li>
+            <li>
+              <strong>Informal resolution first.</strong> Before filing, the
+              party must send a written notice and allow 30 days to attempt
+              informal resolution (contact:
+              <a href="mailto:support@vorbiz.net">support@vorbiz.net</a>).
+            </li>
+            <li>
+              <strong>Small-claims option.</strong> Either party may bring a
+              qualifying claim in small-claims court in Louisiana instead of
+              arbitration.
+            </li>
+            <li>
+              <strong>Class-action &amp; jury trial waiver.</strong> Disputes must
+              be brought individually; class actions and jury trials are waived.
+            </li>
+            <li>
+              <strong>Severability.</strong> If any part of this Section is found
+              unenforceable, the remainder remains in effect.
+            </li>
+          </ul>
+
+          <h3>15. Export &amp; Compliance</h3>
+          <p>
+            You agree to comply with all applicable laws and regulations,
+            including export controls and sanctions. You represent that you are
+            not located in a restricted jurisdiction or on a prohibited list.
+          </p>
+
+          <h3>16. Communications</h3>
+          <p>
+            We may contact you via the app or email (including
+            <a href="mailto:support@vorbiz.net">support@vorbiz.net</a>)
+            regarding your account, service changes, or legal notices.
+          </p>
+
+          <h3>17. Miscellaneous</h3>
+          <ul>
+            <li>
+              <strong>Entire agreement.</strong> These Terms (plus the Privacy
+              Policy) are the entire agreement between you and us regarding the
+              services.
+            </li>
+            <li><strong>No waiver.</strong> Failure to enforce a provision is not a waiver.</li>
+            <li>
+              <strong>Severability.</strong> If any provision is unenforceable,
+              the remainder remains in effect.
+            </li>
+            <li>
+              <strong>Assignment.</strong> You may not assign these Terms without
+              our consent; we may assign them in connection with a merger, sale,
+              or reorganization.
+            </li>
+          </ul>
+
+          <h3>Questions?</h3>
+          <p>Email <a href="mailto:support@vorbiz.net">support@vorbiz.net</a>.</p>
+        </div>
+      </section>
+
+      <section id="privacy" class="my-5">
+        <h2>Privacy Policy – Vorbiz</h2>
+        <div class="card p-4 legal">
             <p><strong>Effective Date:</strong> September 08, 2025</p>
             <p>
               Vorbiz (“we,” “our,” or “us”) respects your privacy. This Privacy


### PR DESCRIPTION
## Summary
- add a Terms of Service section above the existing Privacy Policy content
- include full legal language covering accounts, billing, data handling, and dispute resolution
- update the top navigation to provide an anchor link to the new section

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cb278ac5b8832ea209c5d95fa687bf