### PR TITLE
Align site palette with mobile app theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,27 +19,51 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="feature-graphic.png" />
-    <meta name="theme-color" content="#00937a" />
+    <meta name="theme-color" content="#00796B" />
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
     />
     <style>
       :root {
-        --bs-body-bg: #f1f5f9;
-        --bs-body-color: #0f172a;
-        /* Improved contrast for small text */
-        --bs-secondary-color: #475569;
-        --bs-primary: #00937a;
-        --bs-secondary: #f1f5f9;
-        --bs-info: #44b299;
-        --bs-warning: #db4814;
-        --bs-link-color: #00937a;
-        --bs-link-hover-color: #006d5b;
+        --bs-body-bg: #f5f8f8;
+        --bs-body-bg-rgb: 245, 248, 248;
+        --bs-body-color: #263238;
+        --bs-body-color-rgb: 38, 50, 56;
+        --bs-secondary-color: #455a64;
+        --bs-primary: #00796b;
+        --bs-primary-rgb: 0, 121, 107;
+        --bs-secondary: #455a64;
+        --bs-secondary-rgb: 69, 90, 100;
+        --bs-success: #00695c;
+        --bs-success-rgb: 0, 105, 92;
+        --bs-info: #0277bd;
+        --bs-info-rgb: 2, 119, 189;
+        --bs-warning: #d84315;
+        --bs-warning-rgb: 216, 67, 21;
+        --bs-danger: #d32f2f;
+        --bs-danger-rgb: 211, 47, 47;
+        --bs-link-color: #00796b;
+        --bs-link-hover-color: #006156;
+        --bs-border-color: #90a4ae;
+        --bs-border-color-translucent: rgba(144, 164, 174, 0.35);
+      }
+      body {
+        background: var(--bs-body-bg);
+        color: var(--bs-body-color);
       }
       .navbar {
         background: var(--bs-primary);
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+      }
+      .navbar .navbar-brand,
+      .navbar .nav-link {
+        color: rgba(255, 255, 255, 0.92);
+        font-weight: 600;
+      }
+      .navbar .nav-link:hover,
+      .navbar .nav-link:focus {
+        color: #ffffff;
       }
       .logo {
         width: 22px;
@@ -53,11 +77,13 @@
         gap: 0.5rem;
         padding: 0.375rem 0.75rem;
         border-radius: 50rem;
-        background: rgba(0, 147, 122, 0.1);
+        background: rgba(0, 97, 86, 0.12);
+        color: var(--bs-primary);
+        font-weight: 600;
       }
       .shot img {
         border-radius: 1rem;
-        border: 1px solid rgba(203, 213, 225, 0.5);
+        border: 1px solid rgba(144, 164, 174, 0.45);
         width: 100%;
         height: auto;
       }
@@ -67,22 +93,43 @@
           "Liberation Mono", "Courier New", monospace;
         font-size: 0.8125rem;
         padding: 0.2rem 0.45rem;
-        border: 1px solid rgba(0, 0, 0, 0.2);
+        border: 1px solid rgba(38, 50, 56, 0.24);
         border-bottom-width: 2px;
         border-radius: 6px;
-        background: rgba(0, 0, 0, 0.05);
+        background: rgba(69, 90, 100, 0.08);
       }
       .card {
         background: #ffffff;
-        border-color: rgba(203, 213, 225, 0.5);
+        border-color: rgba(144, 164, 174, 0.45);
         border-radius: 1rem;
+        box-shadow: 0 16px 40px rgba(38, 50, 56, 0.08);
       }
       .card p,
       .card ul {
         color: var(--bs-secondary-color);
       }
+      .figure-caption {
+        color: var(--bs-secondary-color);
+      }
       .legal {
         font-size: 14px;
+        color: var(--bs-secondary-color);
+      }
+      .alert.bg-info {
+        background-color: var(--bs-info);
+        color: #ffffff;
+      }
+      .btn-warning {
+        --bs-btn-color: #ffffff;
+        --bs-btn-bg: #d84315;
+        --bs-btn-border-color: #d84315;
+        --bs-btn-hover-color: #ffffff;
+        --bs-btn-hover-bg: #bf360c;
+        --bs-btn-hover-border-color: #bf360c;
+        --bs-btn-focus-shadow-rgb: 216, 67, 21;
+        --bs-btn-active-color: #ffffff;
+        --bs-btn-active-bg: #bf360c;
+        --bs-btn-active-border-color: #bf360c;
       }
     </style>
   </head>
@@ -150,7 +197,7 @@
               <span class="chip">Fast item entry</span>
               <span class="chip">Clean reports</span>
             </div>
-            <p id="download" class="alert bg-info text-dark border-0 mt-3 mb-0">
+            <p id="download" class="alert bg-info text-light border-0 mt-3 mb-0">
               Coming to Google Play.
             </p>
           </div>


### PR DESCRIPTION
## Summary
- update the landing page theme color and Bootstrap variables to match the mobile app palette
- refresh navigation, chips, cards, and figure captions to improve contrast and readability
- restyle call-to-action alert and warning button for accessible color contrast

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68cb2873da20832ead2ea5a229754570